### PR TITLE
Fix #91: Crash when using RGBA

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -9,7 +9,8 @@ import {
 
 const colors = {
   transparent: "transparent",
-  hex: "#E53E3E",
+  hex6: "#E53E3E",
+  hex8: "#E53E3E80",
   rgb: "rgb(56,161,105)",
   rgba: "rgba(49,151,149, 0.5)",
   hsl: "hsl(170, 45%, 45%)",
@@ -76,8 +77,26 @@ describe("convertConfigColor", () => {
       expect(currentColor["a"]).toBeLessThanOrEqual(1);
     });
 
-    it("should return object from hex", () => {
-      currentColor = convertConfigColor(colors["hex"]);
+    it("should return object from hex6", () => {
+      currentColor = convertConfigColor(colors["hex6"]);
+      // Check if valid object
+      expect(currentColor).toHaveProperty("r");
+      expect(currentColor).toHaveProperty("g");
+      expect(currentColor).toHaveProperty("b");
+      expect(currentColor).toHaveProperty("a");
+      // Check if valid values
+      expect(currentColor["r"]).toBeGreaterThanOrEqual(0);
+      expect(currentColor["r"]).toBeLessThanOrEqual(1);
+      expect(currentColor["g"]).toBeGreaterThanOrEqual(0);
+      expect(currentColor["g"]).toBeLessThanOrEqual(1);
+      expect(currentColor["b"]).toBeGreaterThanOrEqual(0);
+      expect(currentColor["b"]).toBeLessThanOrEqual(1);
+      expect(currentColor["a"]).toBeGreaterThanOrEqual(0);
+      expect(currentColor["a"]).toBeLessThanOrEqual(1);
+    });
+
+    it("should return object from hex8", () => {
+      currentColor = convertConfigColor(colors["hex8"]);
       // Check if valid object
       expect(currentColor).toHaveProperty("r");
       expect(currentColor).toHaveProperty("g");

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -26,11 +26,12 @@ export const convertConfigColor = (color: string): RGBA => {
     color = "rgba(0, 0, 0, 0.0)";
   }
   const { rgba } = parse(color);
+  const alpha = color.length < 8 ? rgba[3] : (rgba[3] / 255)
   return {
     r: rgba[0] / 255,
     g: rgba[1] / 255,
     b: rgba[2] / 255,
-    a: rgba[3]
+    a: alpha
   };
 };
 


### PR DESCRIPTION
The main issue is that, when parsing a RGB hex color, the `parse-color`
module return the alpha between 0 and 1 but, when parsing a RGBA hex
color, the same module return the alpha between 0 and 255 (!!!).