### PR TITLE
Skip the currentColor

### DIFF
--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -62,6 +62,10 @@ export const fetchConfigColors = (config): Array<TailwindColor> => {
           });
         }
       } else {
+        if (colorData === "currentColor") {
+          continue;
+        }
+
         foundColors.push({
           name: color,
           value: convertConfigColor(mergedColors[color])


### PR DESCRIPTION
This PR skips the [` current: 'currentColor',`](https://github.com/tailwindcss/tailwindcss/blob/01657fceb498b680f1ab43746552f0633b7eb830/stubs/defaultConfig.stub.js#L16) section of the default Tailwind stub which currently causes the plugin to fail.

I chose to skip this class as it doesn't really make sense in Figma.

Fixes #105 