### PR TITLE
update manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,5 +3,6 @@
   "id": "738806869514947558",
   "api": "1.0.0",
   "main": "dist/code.js",
-  "ui": "dist/ui.html"
+  "ui": "dist/ui.html",
+  "editorType": ["figma"]
 }


### PR DESCRIPTION
Figma now requires the editor type to be specified in the manifest.json

Quick PR to save you the hassle. ;)